### PR TITLE
Bug wdp190203 13

### DIFF
--- a/src/partials/30_section-features.html
+++ b/src/partials/30_section-features.html
@@ -1,7 +1,7 @@
 <div class="section--features">
   <div class="container">
     <div class="row">
-      <div class="col">
+      <div class="col col-s-6 col-m-6 col-l-3 col-feature">
         <div class="feature-box active">
           <div class="icon"><i class="fas fa-truck"></i></div>
           <div class="content">
@@ -10,7 +10,7 @@
           </div>
         </div>
       </div>
-      <div class="col">
+      <div class="col col-s-6 col-m-6 col-l-3 col-feature">
         <div class="feature-box">
           <div class="icon"><i class="fas fa-headphones"></i></div>
           <div class="content">
@@ -19,7 +19,7 @@
           </div>
         </div>
       </div>
-      <div class="col">
+      <div class="col col-s-6 col-m-6 col-l-3">
         <div class="feature-box">
           <div class="icon"><i class="fas fa-reply-all"></i></div>
           <div class="content">
@@ -28,7 +28,7 @@
           </div>
         </div>
       </div>
-      <div class="col">
+      <div class="col col-s-6 col-m-6 col-l-3">
         <div class="feature-box">
           <div class="icon"><i class="fas fa-bullhorn"></i></div>
           <div class="content">

--- a/src/sass/components/_feature-box.scss
+++ b/src/sass/components/_feature-box.scss
@@ -2,6 +2,7 @@
   border: 1px solid #b6b6b6;
   text-align: center;
   margin-top: 40px;
+  height: calc(100% - 40px);
 
   .icon {
     transform: translateY(-50%);
@@ -34,6 +35,7 @@
   }
 
   .content {
+    padding: 0 5px;
     text-transform: uppercase;
     color: rgb(42, 42, 42);
     margin-top: -0.5rem;
@@ -59,5 +61,17 @@
     .content {
       color: $primary;
     }
+  }
+}
+
+@media screen and (min-width: 320px) and (max-width: 766px) {
+  .col-feature {
+    margin-bottom: 10px;
+  }
+}
+
+@media screen and (min-width: 768px) and (max-width: 1024px) {
+  .col-feature {
+    margin-bottom: 10px;
   }
 }

--- a/src/sass/components/_feature-box.scss
+++ b/src/sass/components/_feature-box.scss
@@ -64,7 +64,7 @@
   }
 }
 
-@media screen and (min-width: 320px) and (max-width: 766px) {
+@media screen and (min-width: 320px) and (max-width: 767px) {
   .col-feature {
     margin-bottom: 10px;
   }


### PR DESCRIPTION
**Cel:**

- dodanie RWD dla sekcji **features** dla urządzeń mobilnych i tabletów 
- poprawa wyświetlania elementów - wielkość kontenerów ma być taka sama

**Rozwiązanie:**

- dodanie klasy pomocniczej **col-feature** dla dodatkowego marginesu (poprawa czytelności)
- dodanie właściwości `height: calc(100% - 40px)`, w celu poprawnego, równego wyświetlania elementów
- dodanie paddingu do **.content** w celu równego wyświetlania treści

**Efekt:**

- poprawne wyświetlanie na urządzeniach mobile i tablets oraz równa wysokość