### PR TITLE
WDP190203-34

### DIFF
--- a/src/sass/components/_product-box.scss
+++ b/src/sass/components/_product-box.scss
@@ -8,8 +8,7 @@
     padding: 80% 10px 0 10px;
 
     background: {
-      color: #f4f5f7;
-      size: contain;
+      size: cover;
       position: center;
       repeat: no-repeat;
     }


### PR DESCRIPTION
CEL:
Poprawa kadrowania obrazków na stronie bez utraty proporcji

PODJĘTE KROKI:
- w sekcji produkty z klasy ".photo" zmieniłem właściwość background-size z contain na cover, usunąłem też background-color
- obie właściwości tyczyły się tego samego elementu.
